### PR TITLE
allow for debug/local mode for testing

### DIFF
--- a/lib/Api.php
+++ b/lib/Api.php
@@ -5,11 +5,20 @@ namespace VHX;
 class Api
 {
   public static $key;
-  const HOST = 'api.vhx.tv';
-  const PROTOCOL = 'https://';
+  public static $host;
+  public static $protocol;
+
   const VERSION = '1.9.0';
 
-  public static function setKey($api_key) {
+  public static function setKey($api_key, $dev = false) {
     self::$key = $api_key;
+
+    if ($dev):
+      self::$host = 'api.crystal.dev';
+      self::$protocol = 'http://';
+    else:
+      self::$host = 'api.vhx.tv';
+      self::$protocol = 'https://';
+    endif;
   }
 }

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -41,7 +41,7 @@ class ApiResource {
   private static function _parseHref($href) {
     if (intval($href, 10)):
       return $href;
-    elseif (strrpos($href, API::HOST)):
+    elseif (strrpos($href, API::$host)):
       if (substr($href, -1) === '/'):
         $href = substr($href, 0, -1);
       endif;
@@ -72,7 +72,7 @@ class ApiResource {
 
   private static function _request($method, $path, $data = array()) {
     $curl = curl_init();
-    $url = API::PROTOCOL . API::HOST . '/' . $path;
+    $url = API::$protocol . API::$host . '/' . $path;
 
     if ($method === 'PUT'):
       $data['_method'] = 'PUT';


### PR DESCRIPTION
This PR adds a debug parameter to the VHX class constructor. In this way if true is passed, the URL host and protocol will be a .dev url for vhx internal use for testing/development.