### PR TITLE
Feature/pass headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,19 @@ $customer = \VHX\Customers::create(array(
   email => 'customer@email.com',
   name => 'First Last',
   product => 'https://api.vhx.tv/products/1'
-});
+));
+```
+
+Headers can be passed in as the last argument, which would either be the second or third argument depending on the method. See each individual method for specifics.
+
+```php
+
+// example video create with header
+$video = \VHX\Videos::create(array(
+  title => 'My Video'
+), array(
+  'VHX-Client-IP' => '0.0.0.0'  
+));
 ```
 
 ### Resources & methods

--- a/lib/Analytics.php
+++ b/lib/Analytics.php
@@ -3,7 +3,7 @@
 namespace VHX;
 
 class Analytics extends ApiResource {
-  public static function report($params = array()) {
-    return self::_list($params);
+  public static function report($params = array(), $headers = null) {
+    return self::_list($params, $headers);
   }
 }

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -103,7 +103,6 @@ class ApiResource {
     endif;
 
     if (count($formatted_headers) > 0):
-      var_dump($formatted_headers);
       curl_setopt($curl, CURLOPT_HTTPHEADER, $formatted_headers);
     endif;
 
@@ -127,7 +126,6 @@ class ApiResource {
     curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 30);
     curl_setopt($curl, CURLOPT_TIMEOUT, 80);
 
-var_dump(curl_getinfo($curl));
     $result = curl_exec($curl);
 
     if ($result === false):

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -143,40 +143,40 @@ class ApiResource {
     endif;
   }
 
-  protected static function _retrieve($id, $scope = null) {
+  protected static function _retrieve($id, $scope = null, $headers) {
     $scope = isset($scope) ? '/' . $scope : '';
     $params = self::_getParameters($id);
     self::_hasID($id, 'retrieve');
     return self::_request('GET', self::_getResourceName() . '/' . $params['id'] . $scope);
   }
 
-  protected static function _list($params) {
+  protected static function _list($params, $headers) {
     return self::_request('GET', self::_getResourceName() . '/', $params);
   }
 
-  protected static function _items($id, $query, $scope = null) {
+  protected static function _items($id, $query, $scope = null, $headers) {
     $scope = isset($scope) ? '/' . $scope : '/items';
     $params = self::_getParameters($id, $query);
     self::_hasID($params['id'], $scope);
     return self::_request('GET', self::_getResourceName() . '/' . $params['id'] . $scope, $params['query']);
   }
 
-  protected static function _create($params) {
-    return self::_request('POST', self::_getResourceName() . '/', $params);
+  protected static function _create($params, $headers) {
+    return self::_request('POST', self::_getResourceName() . '/', $params, $headers);
   }
 
-  protected static function _update($id, $query, $scope = null) {
+  protected static function _update($id, $query, $scope = null, $headers) {
     $scope = isset($scope) ? '/' . $scope : '';
     $params = self::_getParameters($id, $query);
     self::_hasID($params['id'], 'update');
-    return self::_request('PUT', self::_getResourceName() . '/' . $params['id'] . $scope, $params['query']);
+    return self::_request('PUT', self::_getResourceName() . '/' . $params['id'] . $scope, $params['query'], $headers);
   }
 
-  protected static function _delete($id, $query, $scope = null) {
+  protected static function _delete($id, $query, $scope = null, $headers) {
     $scope = isset($scope) ? '/' . $scope : '';
     $params = self::_getParameters($id, $query);
     self::_hasID($params['id'], 'update');
-    return self::_request('DELETE', self::_getResourceName() . '/' . $params['id'] . $scope, $params['query']);
+    return self::_request('DELETE', self::_getResourceName() . '/' . $params['id'] . $scope, $params['query'], $headers);
   }
 
   protected static function _handleResponse($body, $code) {

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -70,9 +70,17 @@ class ApiResource {
     return $params;
   }
 
-  private static function _request($method, $path, $data = array()) {
+  private static function _request($method, $path, $data = array(), $headers) {
     $curl = curl_init();
     $url = API::$protocol . API::$host . '/' . $path;
+
+    if ($headers && is_array($headers)):
+      foreach ($arr as $key => $value):
+        curl_setopt($curl, CURLOPT_HTTPHEADER, $key . ': ' . $value);
+      endforeach;
+    else:
+      $headers = array();
+    endif;
 
     if ($method === 'PUT'):
       $data['_method'] = 'PUT';
@@ -88,11 +96,15 @@ class ApiResource {
       if ($data):
         $data_str = json_encode($data);
         curl_setopt($curl, CURLOPT_POSTFIELDS, $data_str);
-        curl_setopt($curl, CURLOPT_HTTPHEADER, array(
+        array_merge($headers, array(
           'Content-Type: application/json',
           'Content-Length: ' . strlen($data_str))
         );
       endif;
+    endif;
+
+    if (count($headers) > 0):
+      curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
     endif;
 
     if ($method === 'DELETE'):

--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -147,18 +147,18 @@ class ApiResource {
     $scope = isset($scope) ? '/' . $scope : '';
     $params = self::_getParameters($id);
     self::_hasID($id, 'retrieve');
-    return self::_request('GET', self::_getResourceName() . '/' . $params['id'] . $scope);
+    return self::_request('GET', self::_getResourceName() . '/' . $params['id'] . $scope, $headers);
   }
 
   protected static function _list($params, $headers) {
-    return self::_request('GET', self::_getResourceName() . '/', $params);
+    return self::_request('GET', self::_getResourceName() . '/', $params, $headers);
   }
 
   protected static function _items($id, $query, $scope = null, $headers) {
     $scope = isset($scope) ? '/' . $scope : '/items';
     $params = self::_getParameters($id, $query);
     self::_hasID($params['id'], $scope);
-    return self::_request('GET', self::_getResourceName() . '/' . $params['id'] . $scope, $params['query']);
+    return self::_request('GET', self::_getResourceName() . '/' . $params['id'] . $scope, $params['query'], $headers);
   }
 
   protected static function _create($params, $headers) {

--- a/lib/Authorizations.php
+++ b/lib/Authorizations.php
@@ -3,7 +3,7 @@
 namespace VHX;
 
 class Authorizations extends ApiResource {
-  public static function create($params = array()) {
-    return self::_create($params);
+  public static function create($params = array(), $headers = null) {
+    return self::_create($params, $headers);
   }
 }

--- a/lib/Browse.php
+++ b/lib/Browse.php
@@ -3,7 +3,7 @@
 namespace VHX;
 
 class Browse extends ApiResource {
- public static function all($params = array()) {
-   return self::_list($params);
+ public static function all($params = array(), $headers = null) {
+   return self::_list($params, $headers);
  }
 }

--- a/lib/Collections.php
+++ b/lib/Collections.php
@@ -13,7 +13,7 @@ class Collections extends ApiResource {
     return self::_create($params, $headers);
   }
   public static function update($id = null, $params = array(), $headers = null) {
-    return self::_update($id, $params, $headers);
+    return self::_update($id, $params, null, $headers);
   }
   public static function items($id = null, $params = array(), $headers = null) {
     if (is_array($id) && isset($id['collection'])) {

--- a/lib/Collections.php
+++ b/lib/Collections.php
@@ -3,28 +3,28 @@
 namespace VHX;
 
 class Collections extends ApiResource {
-  public static function all($params = array()) {
-    return self::_list($params);
+  public static function all($params = array(), $headers = null) {
+    return self::_list($params, $headers);
   }
-  public static function retrieve($id = null) {
-    return self::_retrieve($id);
+  public static function retrieve($id = null, $headers = null) {
+    return self::_retrieve($id, $headers);
   }
-  public static function create($params = array()) {
-    return self::_create($params);
+  public static function create($params = array(), $headers = null) {
+    return self::_create($params, $headers);
   }
-  public static function update($id = null, $params = array()) {
-    return self::_update($id, $params);
+  public static function update($id = null, $params = array(), $headers = null) {
+    return self::_update($id, $params, $headers);
   }
-  public static function items($id = null, $params = array()) {
+  public static function items($id = null, $params = array(), $headers = null) {
     if (is_array($id) && isset($id['collection'])) {
       $params = $id;
       $id = $id['collection'];
     }
-    return self::_items($id, $params);
+    return self::_items($id, $params, $headers);
   }
 
   // deprecated (same as items)
-  public static function allItems($id = null, $params = array()) {
-    return self::_items($id, $params);
+  public static function allItems($id = null, $params = array(), $headers = null) {
+    return self::_items($id, $params, $headers);
   }
 }

--- a/lib/Collections.php
+++ b/lib/Collections.php
@@ -7,7 +7,7 @@ class Collections extends ApiResource {
     return self::_list($params, $headers);
   }
   public static function retrieve($id = null, $headers = null) {
-    return self::_retrieve($id, $headers);
+    return self::_retrieve($id, null, $headers);
   }
   public static function create($params = array(), $headers = null) {
     return self::_create($params, $headers);

--- a/lib/Customers.php
+++ b/lib/Customers.php
@@ -10,7 +10,7 @@ class Customers extends ApiResource {
     return self::_update($id, $params, $headers);
   }
   public static function retrieve($id = null, $headers = null) {
-    return self::_retrieve($id, $headers);
+    return self::_retrieve($id, null, $headers);
   }
   public static function create($params = array(), $headers = null) {
     return self::_create($params, $headers);

--- a/lib/Customers.php
+++ b/lib/Customers.php
@@ -7,7 +7,7 @@ class Customers extends ApiResource {
     return self::_list($params, $headers);
   }
   public static function update($id = null, $params = array(), $headers = null) {
-    return self::_update($id, $params, $headers);
+    return self::_update($id, $params, null, $headers);
   }
   public static function retrieve($id = null, $headers = null) {
     return self::_retrieve($id, null, $headers);

--- a/lib/Customers.php
+++ b/lib/Customers.php
@@ -3,25 +3,25 @@
 namespace VHX;
 
 class Customers extends ApiResource {
-  public static function all($params = array()) {
-    return self::_list($params);
+  public static function all($params = array(), $headers = null) {
+    return self::_list($params, $headers);
   }
-  public static function update($id = null, $params = array()) {
-    return self::_update($id, $params);
+  public static function update($id = null, $params = array(), $headers = null) {
+    return self::_update($id, $params, $headers);
   }
-  public static function retrieve($id = null) {
-    return self::_retrieve($id);
+  public static function retrieve($id = null, $headers = null) {
+    return self::_retrieve($id, $headers);
   }
-  public static function create($params = array()) {
-    return self::_create($params);
+  public static function create($params = array(), $headers = null) {
+    return self::_create($params, $headers);
   }
-  public static function delete($id = null, $params = array()) {
-    return self::_delete($id, $params);
+  public static function delete($id = null, $params = array(), $headers = null) {
+    return self::_delete($id, $params, $headers);
   }
-  public static function addProduct($id = null, $params = array()) {
-    return self::_update($id, $params, 'products');
+  public static function addProduct($id = null, $params = array(), $headers = null) {
+    return self::_update($id, $params, 'products', $headers);
   }
-  public static function removeProduct($id = null, $params = array()) {
-    return self::_delete($id, $params, 'products');
+  public static function removeProduct($id = null, $params = array(), $headers = null) {
+    return self::_delete($id, $params, 'products', $headers);
   }
 }

--- a/lib/Products.php
+++ b/lib/Products.php
@@ -3,10 +3,10 @@
 namespace VHX;
 
 class Products extends ApiResource {
-  public static function all($params = array()) {
-    return self::_list($params);
+  public static function all($params = array(), $headers = null) {
+    return self::_list($params, $headers);
   }
-  public static function retrieve($id = null) {
-    return self::_retrieve($id);
+  public static function retrieve($id = null, $headers = null) {
+    return self::_retrieve($id, $headers);
   }
 }

--- a/lib/Products.php
+++ b/lib/Products.php
@@ -7,6 +7,6 @@ class Products extends ApiResource {
     return self::_list($params, $headers);
   }
   public static function retrieve($id = null, $headers = null) {
-    return self::_retrieve($id, $headers);
+    return self::_retrieve($id, null, $headers);
   }
 }

--- a/lib/Videos.php
+++ b/lib/Videos.php
@@ -4,7 +4,7 @@ namespace VHX;
 
 class Videos extends ApiResource {
   public static function all($params = array(), $headers = null) {
-    return self::_list($params);
+    return self::_list($params, $headers);
   }
   public static function files($id = null, $params = array(), $headers = null) {
     return self::_items($id, $params, 'files', $headers);
@@ -17,7 +17,7 @@ class Videos extends ApiResource {
     return self::_create($params, $headers);
   }
   public static function update($id = null, $params = array(), $headers = null) {
-    return self::_update($id, $params, $headers);
+    return self::_update($id, $params, null, $headers);
   }
 
   // deprecated (same as files)

--- a/lib/Videos.php
+++ b/lib/Videos.php
@@ -3,25 +3,25 @@
 namespace VHX;
 
 class Videos extends ApiResource {
-  public static function all($params = array()) {
+  public static function all($params = array(), $headers = null) {
     return self::_list($params);
   }
-  public static function files($id = null, $params = array()) {
-    return self::_items($id, $params, 'files');
+  public static function files($id = null, $params = array(), $headers = null) {
+    return self::_items($id, $params, 'files', $headers);
   }
 
-  public static function retrieve($id = null) {
-    return self::_retrieve($id);
+  public static function retrieve($id = null, $headers = null) {
+    return self::_retrieve($id, $headers);
   }
-  public static function create($params = array()) {
-    return self::_create($params);
+  public static function create($params = array(), $headers = null) {
+    return self::_create($params, $headers);
   }
-  public static function update($id = null, $params = array()) {
-    return self::_update($id, $params);
+  public static function update($id = null, $params = array(), $headers = null) {
+    return self::_update($id, $params, $headers);
   }
 
   // deprecated (same as files)
-  public static function allFiles($id = null, $params = array()) {
-    return self::_items($id, $params, 'files');
+  public static function allFiles($id = null, $params = array(), $headers = null) {
+    return self::_items($id, $params, 'files', $headers);
   }
 }

--- a/lib/Videos.php
+++ b/lib/Videos.php
@@ -11,7 +11,7 @@ class Videos extends ApiResource {
   }
 
   public static function retrieve($id = null, $headers = null) {
-    return self::_retrieve($id, $headers);
+    return self::_retrieve($id, null, $headers);
   }
   public static function create($params = array(), $headers = null) {
     return self::_create($params, $headers);

--- a/lib/Watching.php
+++ b/lib/Watching.php
@@ -3,11 +3,11 @@
 namespace VHX;
 
 class Watching extends ApiResource {
-  public static function items($id = null, $params = array()) {
+  public static function items($id = null, $params = array(), $headers = null) {
     if (is_array($id) && isset($id['customer'])) {
       $params = $id;
       $id = $id['customer'];
     }
-    return self::_items($id, $params, 'watching');
+    return self::_items($id, $params, 'watching', $headers);
   }
 }

--- a/lib/Watchlist.php
+++ b/lib/Watchlist.php
@@ -3,25 +3,25 @@
 namespace VHX;
 
 class Watchlist extends ApiResource {
-  public static function items($id = null, $params = array()) {
+  public static function items($id = null, $params = array(), $headers = null) {
     if (is_array($id) && isset($id['customer'])) {
       $params = $id;
       $id = $id['customer'];
     }
-    return self::_items($id, $params, 'watchlist');
+    return self::_items($id, $params, 'watchlist', $headers);
   }
-  public static function addItem($id, $params = array()) {
+  public static function addItem($id, $params = array(), $headers = null) {
     if (is_array($id) && isset($id['customer'])) {
       $params = $id;
       $id = $id['customer'];
     }
-    return self::_update($id, $params, 'watchlist');
+    return self::_update($id, $params, 'watchlist', $headers);
   }
-  public static function removeItem($id, $params = array()) {
+  public static function removeItem($id, $params = array(), $headers = null) {
     if (is_array($id) && isset($id['customer'])) {
       $params = $id;
       $id = $id['customer'];
     }
-    return self::_delete($id, $params, 'watchlist');
+    return self::_delete($id, $params, 'watchlist', $headers);
   }
 }

--- a/tests.sh
+++ b/tests.sh
@@ -1,0 +1,1 @@
+php vendor/bin/phpunit --colors=always tests

--- a/tests/CustomersTest.php
+++ b/tests/CustomersTest.php
@@ -12,7 +12,9 @@ use PHPUnit\Framework\TestCase;
 
 class CustomersTest extends TestCase {
   public function testAll() {
-    $customers = \VHX\Customers::all();
+    $customers = \VHX\Customers::all(array(), array(
+      'Foo-Header' => 'bar'
+    ));
     $this->assertArrayHasKey('_links', $customers);
     $this->assertArrayHasKey('_embedded', $customers);
     $this->assertArrayHasKey('count', $customers);
@@ -21,7 +23,9 @@ class CustomersTest extends TestCase {
 
   public function testRetrieve() {
     $params = new Params();
-    $customer = \VHX\Customers::retrieve($params->customer());
+    $customer = \VHX\Customers::retrieve($params->customer(), array(
+      'Foo-Header' => 'bar'
+    ));
     $this->assertArrayHasKey('_links', $customer);
     $this->assertArrayHasKey('_embedded', $customer);
     $this->assertArrayHasKey('email', $customer);


### PR DESCRIPTION
Adds header support, along the same lines as @ksheurs added to the Ruby Client. Headers can be passed as an array via the last param (either the second or third param depending on the method).

Example:

```php
$customer = \VHX\Customers::create(array(
  'name' => 'First Last',
  'email' => 'customer@email.com',
  'product' => 'https://api.vhx.tv/products/1'
), array(
  'VHX-Client-IP' => '0.0.0.0'
));
```

@ksheurs 👀 