### PR TITLE
Fix fatal error in collection episodes listing

### DIFF
--- a/lib/Collections.php
+++ b/lib/Collections.php
@@ -20,7 +20,7 @@ class Collections extends ApiResource {
       $params = $id;
       $id = $id['collection'];
     }
-    return self::_items($id, $params, $headers);
+    return self::_items($id, $params, null, $headers);
   }
 
   // deprecated (same as items)


### PR DESCRIPTION
Add null as scope parameter to _items call