### PR TITLE
Drop cURL debug code

### DIFF
--- a/lib/ApiResource.php
+++ b/lib/ApiResource.php
@@ -120,7 +120,6 @@ class ApiResource {
     curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
     curl_setopt($curl, CURLOPT_USERPWD, API::$key . ':');
     curl_setopt($curl, CURLOPT_URL, $url);
-    curl_setopt($curl, CURLOPT_VERBOSE, 1);
     curl_setopt($curl, CURLOPT_HEADER, true);
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
     curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 30);


### PR DESCRIPTION
This code is causing any call to the VHX API made using this package to output its raw HTTP request back to the stream. Most annoying when using CLI.